### PR TITLE
Symfony 5 updates

### DIFF
--- a/integration/symfony.md
+++ b/integration/symfony.md
@@ -20,7 +20,7 @@ use Spiral\RoadRunner\PSR7Client;
 use Spiral\RoadRunner\Worker;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 use Zend\Diactoros\ResponseFactory;


### PR DESCRIPTION
Debug component is deprecated in favor of ErrorHandler component