### PR TITLE
Add `baldinof/roadrunner-bundle` in Symfony integrations

### DIFF
--- a/integration/symfony.md
+++ b/integration/symfony.md
@@ -1,99 +1,16 @@
 # Symfony Framework
-> References:
-> * https://github.com/spiral/roadrunner/issues/42
-> * https://github.com/spiral/roadrunner/issues/18
 
-A worker to serve apps based on the default Symfony skeleton:
+List of available integrations.
 
-```bash
-composer req spiral/roadrunner symfony/psr-http-message-bridge
-```
+Repository | Status
+--- | ---
+https://github.com/baldinof/roadrunner-bundle | [![Version][baldinof_badge_php_version]][baldinof_link_packagist] [![Build Status][baldinof_badge_build_status]][baldinof_link_build_status] [![License][baldinof_badge_license]][baldinof_link_license]
 
-worker.php:
-```php
-<?php
-ini_set('display_errors', 'stderr');
 
-use App\Kernel;
-use Spiral\Goridge\StreamRelay;
-use Spiral\RoadRunner\PSR7Client;
-use Spiral\RoadRunner\Worker;
-use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
-use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use Symfony\Component\ErrorHandler\Debug;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpFoundation\Request;
-use Zend\Diactoros\ResponseFactory;
-use Zend\Diactoros\ServerRequestFactory;
-use Zend\Diactoros\StreamFactory;
-use Zend\Diactoros\UploadedFileFactory;
-
-require 'vendor/autoload.php';
-
-// The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException(
-            'APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.'
-        );
-    }
-    (new Dotenv())->load(__DIR__.'/.env');
-}
-
-$env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ('prod' !== $env));
-
-if ($debug) {
-    umask(0000);
-
-    Debug::enable();
-}
-
-if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
-    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
-}
-
-if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
-    Request::setTrustedHosts(explode(',', $trustedHosts));
-}
-
-$kernel = new Kernel($env, $debug);
-$relay = new StreamRelay(STDIN, STDOUT);
-$psr7 = new PSR7Client(new Worker($relay));
-$httpFoundationFactory = new HttpFoundationFactory();
-$psrHttpFactory = new PsrHttpFactory(
-    new ServerRequestFactory,
-    new StreamFactory,
-    new UploadedFileFactory,
-    new ResponseFactory
-);
-
-while ($req = $psr7->acceptRequest()) {
-    try {
-        $request = $httpFoundationFactory->createRequest($req);
-        $response = $kernel->handle($request);
-        $psr7->respond($psrHttpFactory->createResponse($response));
-        $kernel->terminate($request, $response);
-        $kernel->reboot(null);
-    } catch (\Throwable $e) {
-        $psr7->getWorker()->error((string)$e);
-    }
-}
-```
-
-Corresponding `.rr.yaml` config.
-
-```yaml
-http:
-  address: 0.0.0.0:8080
-  workers:
-    command: "php test-sf/worker.php"
-    pool:
-      numWorkers: 4
-
-static:
-  dir:   "test-sf/public"
-```
-
-# Session Issues
-Default Symfony session mechanism relies on default session handler and it's cookie setters. Check this issue for more details: https://github.com/spiral/roadrunner/issues/18
+[baldinof_badge_packagist_version]:https://img.shields.io/packagist/v/baldinof/roadrunner-bundle.svg?maxAge=180
+[baldinof_badge_php_version]:https://img.shields.io/packagist/php-v/baldinof/roadrunner-bundle.svg?longCache=true
+[baldinof_badge_build_status]:https://img.shields.io/github/workflow/status/baldinof/roadrunner-bundle/CI
+[baldinof_badge_license]:https://img.shields.io/packagist/l/baldinof/roadrunner-bundle.svg?longCache=true
+[baldinof_link_packagist]:https://packagist.org/packages/baldinof/roadrunner-bundle
+[baldinof_link_build_status]:https://github.com/baldinof/roadrunner-bundle/actions
+[baldinof_link_license]:https://github.com/baldinof/roadrunner-bundle/blob/master/LICENSE


### PR DESCRIPTION
Hi,

This adds a reference to the [baldinof/roadrunner-bundle](https://github.com/baldinof/roadrunner-bundle) symfony integration.

See https://github.com/spiral/roadrunner/issues/18#issuecomment-586720908