### PR TITLE
Update laravel.md

### DIFF
--- a/integration/laravel.md
+++ b/integration/laravel.md
@@ -3,29 +3,6 @@ List of available integrations.
 
 Repository | Status
 --- | ---
-https://github.com/avto-dev/roadrunner-laravel | [![Version][badge_php_version]][link_packagist] [![Build Status][badge_build_status]][link_build_status] [![License][badge_license]][link_license]
-https://github.com/UPDG/roadrunner-laravel | Not available
-https://github.com/Hunternnm/laravel-roadrunner | Not available
-
-[badge_packagist_version]:https://img.shields.io/packagist/v/avto-dev/roadrunner-laravel.svg?maxAge=180
-[badge_php_version]:https://img.shields.io/packagist/php-v/avto-dev/roadrunner-laravel.svg?longCache=true
-[badge_build_status]:https://travis-ci.org/avto-dev/roadrunner-laravel.svg?branch=master
-[badge_coverage]:https://img.shields.io/codecov/c/github/avto-dev/roadrunner-laravel/master.svg?maxAge=60
-[badge_downloads_count]:https://img.shields.io/packagist/dt/avto-dev/roadrunner-laravel.svg?maxAge=180
-[badge_license]:https://img.shields.io/packagist/l/avto-dev/roadrunner-laravel.svg?longCache=true
-[badge_release_date]:https://img.shields.io/github/release-date/avto-dev/roadrunner-laravel.svg?style=flat-square&maxAge=180
-[badge_commits_since_release]:https://img.shields.io/github/commits-since/avto-dev/roadrunner-laravel/latest.svg?style=flat-square&maxAge=180
-[badge_issues]:https://img.shields.io/github/issues/avto-dev/roadrunner-laravel.svg?style=flat-square&maxAge=180
-[badge_pulls]:https://img.shields.io/github/issues-pr/avto-dev/roadrunner-laravel.svg?style=flat-square&maxAge=180
-[link_releases]:https://github.com/avto-dev/roadrunner-laravel/releases
-[link_packagist]:https://packagist.org/packages/avto-dev/roadrunner-laravel
-[link_build_status]:https://travis-ci.org/avto-dev/roadrunner-laravel
-[link_coverage]:https://codecov.io/gh/avto-dev/roadrunner-laravel/
-[link_changes_log]:https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md
-[link_issues]:https://github.com/avto-dev/roadrunner-laravel/issues
-[link_create_issue]:https://github.com/avto-dev/roadrunner-laravel/issues/new/choose
-[link_commits]:https://github.com/avto-dev/roadrunner-laravel/commits
-[link_pulls]:https://github.com/avto-dev/roadrunner-laravel/pulls
-[link_license]:https://github.com/avto-dev/roadrunner-laravel/blob/master/LICENSE
-[getcomposer]:https://getcomposer.org/download/
-[roadrunner]:https://github.com/spiral/roadrunner
+[spiral/roadrunner-laravel](https://github.com/spiral/roadrunner-laravel) | ![Version](https://img.shields.io/packagist/php-v/spiral/roadrunner-laravel.svg) ![Build Status](https://img.shields.io/github/workflow/status/spiral/roadrunner-laravel/build) ![Coverage](https://img.shields.io/codecov/c/github/spiral/roadrunner-laravel/master.svg) ![License](https://img.shields.io/packagist/l/spiral/roadrunner-laravel)
+[UPDG/roadrunner-laravel](https://github.com/UPDG/roadrunner-laravel) | ![License](https://img.shields.io/packagist/l/UPDG/roadrunner-laravel.svg)
+[Hunternnm/laravel-roadrunner](https://github.com/Hunternnm/laravel-roadrunner) | ![License](https://img.shields.io/packagist/l/Hunternnm/laravel-roadrunner.svg)

--- a/integration/laravel.md
+++ b/integration/laravel.md
@@ -4,5 +4,5 @@ List of available integrations.
 Repository | Status
 --- | ---
 [spiral/roadrunner-laravel](https://github.com/spiral/roadrunner-laravel) | ![Version](https://img.shields.io/packagist/php-v/spiral/roadrunner-laravel.svg) ![Build Status](https://img.shields.io/github/workflow/status/spiral/roadrunner-laravel/build) ![Coverage](https://img.shields.io/codecov/c/github/spiral/roadrunner-laravel/master.svg) ![License](https://img.shields.io/packagist/l/spiral/roadrunner-laravel)
-[UPDG/roadrunner-laravel](https://github.com/UPDG/roadrunner-laravel) | ![License](https://img.shields.io/packagist/l/UPDG/roadrunner-laravel.svg)
-[Hunternnm/laravel-roadrunner](https://github.com/Hunternnm/laravel-roadrunner) | ![License](https://img.shields.io/packagist/l/Hunternnm/laravel-roadrunner.svg)
+[updg/roadrunner-laravel](https://github.com/UPDG/roadrunner-laravel) | ![License](https://img.shields.io/packagist/l/UPDG/roadrunner-laravel.svg)
+[hunternnm/laravel-roadrunner](https://github.com/Hunternnm/laravel-roadrunner) | ![License](https://img.shields.io/packagist/l/Hunternnm/laravel-roadrunner.svg)


### PR DESCRIPTION
- `https://github.com/avto-dev/roadrunner-laravel` replaced with `https://github.com/spiral/roadrunner-laravel`
- License badges added for packages `UPDG/roadrunner-laravel` and `Hunternnm/laravel-roadrunner`
- Repo links replaced with package names (links keeped)
- Small cleanup