### PR TITLE
Add example integration for mezzio to docs

### DIFF
--- a/integration/mezzio.md
+++ b/integration/mezzio.md
@@ -1,0 +1,6 @@
+# [Mezzio](https://docs.mezzio.dev/)
+List of available integrations.
+
+Repository | Status
+--- | ---
+[bcremer/roadrunner-mezzio-integration](https://github.com/bcremer/roadrunner-mezzio-integration)|MIT License 

--- a/manifest.json
+++ b/manifest.json
@@ -61,7 +61,8 @@
       "integration/ubiquity": "Ubiquity Framework",
       "integration/zend": "Zend Expressive",
       "integration/yii": "Yii2 and Yii3",
-      "integration/phalcon": "Phalcon3 and Phalcon4"
+      "integration/phalcon": "Phalcon3 and Phalcon4",
+      "integration/mezzio": "Mezzio"
     }
   },
   {

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ RoadRunner is an open-source (MIT licensed), high-performance PHP application se
     * [Zend Expressive](https://github.com/sergey-telpuk/roadrunner-zend-expressive-integration)
     * [Yii2 and Yii3](integration/yii.md)
     * [Phalcon3 and Phalcon4](integration/phalcon.md)
+    * [Mezzio](integration/mezzio.md)
     * [**All Composer Libraries**](https://packagist.org/packages/spiral/roadrunner/dependents)
 * Docker
     * [Ports and Containers](docker/ports.md)


### PR DESCRIPTION
Adds an example how to integrate an existing [Mezzio](https://docs.mezzio.dev/) application with RoadRunner.