### PR TITLE
Add example integration for chubbyphp framework to docs

### DIFF
--- a/integration/chubbyphp.md
+++ b/integration/chubbyphp.md
@@ -1,0 +1,6 @@
+# [Chubbyphp Framework](https://github.com/chubbyphp/chubbyphp-framework)
+List of available integrations.
+
+Repository | Status
+--- | ---
+[chubbyphp/chubbyphp-framework](https://github.com/chubbyphp/chubbyphp-framework/blob/master/doc/Server/Roadrunner.md)|MIT License

--- a/manifest.json
+++ b/manifest.json
@@ -62,7 +62,8 @@
       "integration/zend": "Zend Expressive",
       "integration/yii": "Yii2 and Yii3",
       "integration/phalcon": "Phalcon3 and Phalcon4",
-      "integration/mezzio": "Mezzio"
+      "integration/mezzio": "Mezzio",
+      "integration/chubbyphp": "Chubbyphp Framework"
     }
   },
   {

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ RoadRunner is an open-source (MIT licensed), high-performance PHP application se
     * [Yii2 and Yii3](integration/yii.md)
     * [Phalcon3 and Phalcon4](integration/phalcon.md)
     * [Mezzio](integration/mezzio.md)
+    * [Chubbyphp Framework](integration/chubbyphp.md)
     * [**All Composer Libraries**](https://packagist.org/packages/spiral/roadrunner/dependents)
 * Docker
     * [Ports and Containers](docker/ports.md)


### PR DESCRIPTION
Adds an example how to integrate an existing [Chubbyphp Framework](https://github.com/chubbyphp/chubbyphp-framework) application with RoadRunner.