### PR TITLE
Add Symfony Runtime as roadrunner integration

### DIFF
--- a/integration/symfony.md
+++ b/integration/symfony.md
@@ -5,6 +5,7 @@ List of available integrations.
 Repository | Status
 --- | ---
 https://github.com/baldinof/roadrunner-bundle | [![Version][baldinof_badge_php_version]][baldinof_link_packagist] [![Build Status][baldinof_badge_build_status]][baldinof_link_build_status] [![License][baldinof_badge_license]][baldinof_link_license]
+https://github.com/php-runtime/roadrunner-symfony-nyholm | [![Version][phpruntime_badge_php_version]][phpruntime_link_packagist] [![License][phpruntime_badge_license]][phpruntime_link_license]
 
 [baldinof_badge_packagist_version]:https://img.shields.io/packagist/v/baldinof/roadrunner-bundle.svg?maxAge=180
 [baldinof_badge_php_version]:https://img.shields.io/packagist/php-v/baldinof/roadrunner-bundle.svg?longCache=true
@@ -13,3 +14,11 @@ https://github.com/baldinof/roadrunner-bundle | [![Version][baldinof_badge_php_v
 [baldinof_link_packagist]:https://packagist.org/packages/baldinof/roadrunner-bundle
 [baldinof_link_build_status]:https://github.com/baldinof/roadrunner-bundle/actions
 [baldinof_link_license]:https://github.com/baldinof/roadrunner-bundle/blob/master/LICENSE
+
+
+[phpruntime_badge_packagist_version]:https://img.shields.io/packagist/v/runtime/roadrunner-symfony-nyholm.svg?maxAge=180
+[phpruntime_badge_php_version]:https://img.shields.io/packagist/php-v/symfony/runtime.svg?longCache=true
+[phpruntime_badge_license]:https://img.shields.io/packagist/l/runtime/roadrunner-symfony-nyholm.svg?longCache=true
+[phpruntime_link_packagist]:https://packagist.org/packages/runtime/roadrunner-symfony-nyholm
+[phpruntime_link_build_status]:https://github.com/php-runtime/runtime/actions
+[phpruntime_link_license]:https://github.com/php-runtime/roadrunner-symfony-nyholm/blob/master/LICENSE

--- a/integration/symfony.md
+++ b/integration/symfony.md
@@ -15,7 +15,6 @@ https://github.com/php-runtime/roadrunner-symfony-nyholm | [![Version][phpruntim
 [baldinof_link_build_status]:https://github.com/baldinof/roadrunner-bundle/actions
 [baldinof_link_license]:https://github.com/baldinof/roadrunner-bundle/blob/master/LICENSE
 
-
 [phpruntime_badge_packagist_version]:https://img.shields.io/packagist/v/runtime/roadrunner-symfony-nyholm.svg?maxAge=180
 [phpruntime_badge_php_version]:https://img.shields.io/packagist/php-v/symfony/runtime.svg?longCache=true
 [phpruntime_badge_license]:https://img.shields.io/packagist/l/runtime/roadrunner-symfony-nyholm.svg?longCache=true


### PR DESCRIPTION
With the new Symfony 5.3 release a new component was provided by symfony the `symfony/runtime`.
In the new @php-runtime project maintained by Symfony Team Core Member @Nyholm a roadrunner integration was created.

All php-runtime project are handled in the following mono repository: https://github.com/php-runtime/runtime