### PR TITLE
Further detail and updates to middleware documentation

### DIFF
--- a/http/middleware.md
+++ b/http/middleware.md
@@ -36,7 +36,7 @@ func (g *Plugin) Name() string {
 
 > Middleware must correspond to the following [interface](https://github.com/spiral/roadrunner/blob/master/plugins/http/plugin.go#L37) and be named.
 
-We have to register this service after in the `internal/container/plugin.go` file in order to properly resolve dependency:
+We have to register this service after in the [`internal/container/plugin.go`](https://github.com/spiral/roadrunner-binary/blob/master/internal/container/plugins.go#L31) file in order to properly resolve dependency:
 
 ```golang
 import (

--- a/http/middleware.md
+++ b/http/middleware.md
@@ -33,26 +33,30 @@ func (g *Plugin) Name() string {
 
 > Middleware must correspond to the following [interface](https://github.com/spiral/roadrunner/blob/master/plugins/http/plugin.go#L37) and be named.
 
-We have to register this service after in the `main.go` file in order to properly resolve dependency:
+We have to register this service after in the `internal/container/plugin.go` file in order to properly resolve dependency:
 
 ```golang
-container, err := endure.NewContainer(nil, endure.SetLogLevel(endure.ErrorLevel), endure.RetryOnFail(false))
-if err != nil {
-    panic(err)
-}
-err = container.Register(&http.Service{})
-if err != nil {
-    panic(err)
-}
-err = container.Register(&custom.Service{})
-xif err != nil {
-    panic(err)
-}
+import (
+    "middleware"
+)
 
-err = container.RegisterAll(  
-  // ...
-        &middleware.Plugin{},
- )
+func Plugins() []interface{} {
+	return []interface{}{
+    // ...
+    
+    // middleware
+    &middleware.Plugin{},
+    
+    // ...
+ }
+```
+
+You should also make sure you configure the middleware to be used via the config or the command line otherwise the plugin will be loaded but the middleware
+will not be used with incoming requests.
+
+```yaml
+http:
+    middleware: [ "middleware" ]
 ```
 
 ### PSR7 Attributes

--- a/http/middleware.md
+++ b/http/middleware.md
@@ -22,6 +22,9 @@ func (g *Plugin) Init() error {
 func (g *Plugin) Middleware(next http.Handler) http.Handler {
     return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     // do something
+    // ...
+    // continue request through the middleware pipeline
+    next.ServeHTTP(w, r)
  })
 }
 
@@ -51,11 +54,11 @@ func Plugins() []interface{} {
  }
 ```
 
-You should also make sure you configure the middleware to be used via the config or the command line otherwise the plugin will be loaded but the middleware
-will not be used with incoming requests.
+You should also make sure you configure the middleware to be used via the [config or the command line](https://roadrunner.dev/docs/intro-config) otherwise the plugin will be loaded but the middleware will not be used with incoming requests.
 
 ```yaml
 http:
+    # provide the name of the plugin as provided by the plugin in the example's case, "middleware"
     middleware: [ "middleware" ]
 ```
 


### PR DESCRIPTION
# Changes

* Describe the process of adding the plugin based on the current system as docs referenced how to do it with previous versions of RoadRunner.
* Adds details about making sure the middleware is specified in the config file
* Provides an example in the Middleware function example of how to continue the request through the rest of the middleware.

# Why

I spent about a day trying to make the middleware I'd created work as per the example and despite the plugin loading the Middleware function never executed, I eventually realised I also needed to setup the plugin in the config to make it execute.