### PR TITLE
Add hint about php sockets

### DIFF
--- a/intro/install.md
+++ b/intro/install.md
@@ -13,6 +13,8 @@ $ ./vendor/bin/rr get
 Server binary will be available in the root of your project.
 
 > PHP's extensions `php-curl` and `php-zip` are required to download RoadRunner automatically.
+> PHP's extensions `php-sockets` maybe need to be installed to run roadrunner.
+> Check with `pphp --modules` your installed extensions.
 
 #### Building RoadRunner
 RoadRunner can be compiled on Linux, OSX, Windows and other 64 bit environments as the only requirement are **Go 1.13+**.

--- a/intro/install.md
+++ b/intro/install.md
@@ -13,8 +13,8 @@ $ ./vendor/bin/rr get
 Server binary will be available in the root of your project.
 
 > PHP's extensions `php-curl` and `php-zip` are required to download RoadRunner automatically.
-> PHP's extensions `php-sockets` maybe need to be installed to run roadrunner.
-> Check with `pphp --modules` your installed extensions.
+> PHP's extensions `php-sockets` need to be installed to run roadrunner.
+> Check with `php --modules` your installed extensions.
 
 #### Building RoadRunner
 RoadRunner can be compiled on Linux, OSX, Windows and other 64 bit environments as the only requirement are **Go 1.13+**.


### PR DESCRIPTION
I installed roadrunner and it seems they have a requirement to the `sockets` package which seems not be part of the official php docker images:

```bash
composer why ext-sockets
spiral/goridge            v3.1.1  requires  ext-sockets (*)
spiral/roadrunner-worker  v2.0.3  requires  ext-sockets (*)
```