### PR TITLE
Prevent worker reboot on bad http input

### DIFF
--- a/php/worker.md
+++ b/php/worker.md
@@ -22,7 +22,14 @@ $psrFactory = new Psr7\Factory\Psr17Factory();
 
 $worker = new RoadRunner\Http\PSR7Worker($worker, $psrFactory, $psrFactory, $psrFactory);
 
-while ($req = $worker->waitRequest()) {
+while (true) {
+    try {
+        $req = $worker->waitRequest();
+    } catch (\Throwable $e) {
+        $worker->respond($psrFactory->createResponse(400));
+        continue;
+    }
+    
     try {
         $rsp = new Psr7\Response();
         $rsp->getBody()->write('Hello world!');


### PR DESCRIPTION
With this configuration, bad user input crash roadrunner and force worker to reload. `nyholm/psr7` is too strict (for the good and the bad). This configuration prevents to DDoS roadrunner applications. By fuzzing rr at http layer, you will discover all cases, I will not explain them all here. A simple demo:

```
curl -H "0: hi" https://roadrunner.dev
```

This behavior is directly dependent on the underlying psr7 lib. Invalid user input must not affect RR app