### PR TITLE
Clarify boltdb configuration (`dir`, `file`)

### DIFF
--- a/beep-beep/jobs.md
+++ b/beep-beep/jobs.md
@@ -210,7 +210,7 @@ Below is a more detailed description of each of the in-memory-specific options:
   PQ size is set to 100 and prefetch to 100000, you'll be able to push up to
   prefetch number of jobs even if PQ is full.
 
-- `file` - boltdb database file to use. Might be a path with file: `foo/bar/rr1.db`. Default: `rr.db`. 
+- `file` - boltdb database file to use. Might be a full path with file: `/foo/bar/rr1.db`. Default: `rr.db`. 
 
 
 ### AMQP Driver

--- a/beep-beep/kv.md
+++ b/beep-beep/kv.md
@@ -109,11 +109,7 @@ kv:
 
     # Optional section.
     # Default: "rr.db"
-    file: "rr.db"
-
-    # Optional section.
-    # Default: "."
-    dir: "."
+    file: "./rr.db"
 
     # Optional section.
     # Default: 0777
@@ -130,15 +126,11 @@ kv:
 
 Below is a more detailed description of each of the boltdb-specific options:
 
-- `file` - Database file pathname name. In the case that such a file does not
+- `file` - Database file path name. In the case that such a file does not
   exist in, RoadRunner will create this file on its own at startup. Note that this
   must be an existing directory, otherwise a "The system cannot find the path
   specified" error will be occurred, indicating that the full database pathname is
   invalid.
-
-- `dir` - The directory prefix string where the database file will be located.
-  When forming the path to the file, this prefix will be added before the pathname
-  defined in `file` section.
 
 - `permissions` - The file permissions in UNIX format of the database file, set
   at the time of its creation. If the file already exists, the permissions will

--- a/beep-beep/kv.md
+++ b/beep-beep/kv.md
@@ -130,7 +130,7 @@ Below is a more detailed description of each of the boltdb-specific options:
   exist in, RoadRunner will create this file on its own at startup. Note that this
   must be an existing directory, otherwise a "The system cannot find the path
   specified" error will be occurred, indicating that the full database pathname is
-  invalid.
+  invalid. Might be a full path with file: `/foo/bar/rr1.db`. Default: `rr.db`.
 
 - `permissions` - The file permissions in UNIX format of the database file, set
   at the time of its creation. If the file already exists, the permissions will


### PR DESCRIPTION
Proposed change:
- [X] Change the documentation to be more verbose about how to use the `file` flag in the boltdb configuration.
- [X] Removed the deprecated `dir` flag from the kv configuration example.

Issue:
[Issue #101](https://github.com/spiral/roadrunner-binary/issues/101)