### PR TITLE
Correct variable name in php/worker.md example

### DIFF
--- a/php/worker.md
+++ b/php/worker.md
@@ -20,7 +20,7 @@ include "vendor/autoload.php";
 $worker = RoadRunner\Worker::create();
 $psrFactory = new Psr7\Factory\Psr17Factory();
 
-$worker = new RoadRunner\Http\PSR7Worker($worker, $psrFactory, $psrFactory, $psrFactory);
+$psr7 = new RoadRunner\Http\PSR7Worker($worker, $psrFactory, $psrFactory, $psrFactory);
 
 while (true) {
     try {


### PR DESCRIPTION
$worker received an assignment on line 23. $psr7 was subsequently used on line 27. The former was seemingly intended to reference the latter.