### PR TITLE
Update grpc default address

### DIFF
--- a/docs/en/app-server/grpc.md
+++ b/docs/en/app-server/grpc.md
@@ -17,7 +17,7 @@ grpc:
   # GRPC address to listen
   #
   # This option is required
-  listen: "tcp://localhost:9001"
+  listen: "tcp://127.0.0.1:9001"
 
   # GRPC reflection server [SINCE 2.11]
   #


### PR DESCRIPTION
In some cases localhost causes the error below

```
handle_serve_command: Serve error:
        endure_start:
        endure_serve_internal: Function call error:
        endure_call_serve_fn: got initial serve error from the Vertex grpc.Plugin, stopping execution, error: grpc_plugin_serve: address localhost: no suitable address found
```