### PR TITLE
Fixes composer package names

### DIFF
--- a/docs/en/app-server/aws-lambda.md
+++ b/docs/en/app-server/aws-lambda.md
@@ -44,7 +44,7 @@ while ($req = $psr7->waitRequest()) {
 
 ```
 
-Name this file `handler.php` and put it into the root of your project. Make sure to run `composer require spiral/roadrunner`.
+Name this file `handler.php` and put it into the root of your project. Make sure to run `composer require spiral/roadrunner-http nyholm/psr7`.
 
 ### Application
 We can create a simple application to demonstrate how it works:

--- a/docs/en/intro/install.md
+++ b/docs/en/intro/install.md
@@ -24,7 +24,7 @@ Configuration located in the `.rr.yaml` file ([full sample](https://github.com/r
 You can also install RoadRunner automatically using command shipped with the composer package, run:
 
 ```bash
-composer require spiral/roadrunner:v2.0 nyholm/psr7
+composer require spiral/roadrunner-cli
 ./vendor/bin/rr get-binary
 ```
 

--- a/docs/en/php/worker.md
+++ b/docs/en/php/worker.md
@@ -6,7 +6,7 @@ In order to run your PHP application, you must create a worker endpoint and conf
 install the required package using [Composer](https://getcomposer.org/).
 
 ```bash
-composer require spiral/roadrunner nyholm/psr7
+composer require spiral/roadrunner-http nyholm/psr7
 ```
 
 Simplest entrypoint with PSR-7 server API might look like:


### PR DESCRIPTION
Fixes composer package names that should be used to download RoadRunner from Github repository and to install HTTP worker

fixes [#1540](https://github.com/roadrunner-server/roadrunner/issues/1540)