### PR TITLE
Fix build badge

### DIFF
--- a/docs/en/integration/laravel.md
+++ b/docs/en/integration/laravel.md
@@ -5,7 +5,7 @@ List of available community integrations.
 
 Repository | Status
 --- | ---
-[spiral/roadrunner-laravel](https://github.com/spiral/roadrunner-laravel) | ![Version](https://img.shields.io/packagist/php-v/spiral/roadrunner-laravel.svg) ![Build Status](https://img.shields.io/github/workflow/status/spiral/roadrunner-laravel/build) ![Coverage](https://img.shields.io/codecov/c/github/spiral/roadrunner-laravel/master.svg) ![License](https://img.shields.io/packagist/l/spiral/roadrunner-laravel)
+[spiral/roadrunner-laravel](https://github.com/spiral/roadrunner-laravel) | ![Version](https://img.shields.io/packagist/php-v/spiral/roadrunner-laravel.svg) ![Build Status](https://img.shields.io/github/actions/workflow/status/spiral/roadrunner-laravel/tests.yml?branch=master&maxAge=30) ![Coverage](https://img.shields.io/codecov/c/github/spiral/roadrunner-laravel/master.svg) ![License](https://img.shields.io/packagist/l/spiral/roadrunner-laravel)
 [updg/roadrunner-laravel](https://github.com/UPDG/roadrunner-laravel) | ![License](https://img.shields.io/packagist/l/UPDG/roadrunner-laravel.svg)
 [hunternnm/laravel-roadrunner](https://github.com/Hunternnm/laravel-roadrunner) | ![License](https://img.shields.io/packagist/l/Hunternnm/laravel-roadrunner.svg)
 


### PR DESCRIPTION
## Problem

Broken `build` badge on the page [Integrations / Laravel](https://roadrunner.dev/docs/integration-laravel/2.x/en)
 
![изображение](https://user-images.githubusercontent.com/6119929/233264182-4d8ff3fd-cb6c-45c2-9431-f4bd03fadfa9.png)
