### PR TITLE
Remove non-existing options from Centrifugo config

### DIFF
--- a/docs/en/plugins/centrifuge.md
+++ b/docs/en/plugins/centrifuge.md
@@ -97,10 +97,8 @@ For example:
     "*"
   ],
   "token_hmac_secret_key": "test",
-  "publish": true,
   "proxy_publish": true,
   "proxy_subscribe": true,
-  "proxy_connect": true,
   "allow_subscribe_for_client": true,
   "proxy_connect_endpoint": "grpc://127.0.0.1:10001",
   "proxy_connect_timeout": "10s",


### PR DESCRIPTION
Hello!

Centrifugo does not have `publish` and `proxy_connect` options.