### PR TITLE
Update metrics and readiness docs

### DIFF
--- a/docs/en/http/http.md
+++ b/docs/en/http/http.md
@@ -525,3 +525,9 @@ http:
 
 So in this case the request gets into the `sendfile` middleware, then `gzip` and `static`. And vice versa from the
 response.
+
+## Request queues
+
+RR has an internal queue for requests. The `allocate_timeout` is used to assign a worker to the request. 
+If your worker works for 1 minute for example, but `allocate_timeout` is equal to 30 seconds, after this timeout, RR will start rejecting the first request in queue. 
+Then +30s for the second, and so on and so forth.

--- a/docs/en/lab/health.md
+++ b/docs/en/lab/health.md
@@ -31,6 +31,10 @@ The health check endpoint will return `HTTP 200` if there is at least one worker
 no workers ready to service requests, the endpoint will return `HTTP 500`. If there are any other errors, the endpoint
 will also return `HTTP 500`.
 
+The readiness check endpoint will return `HTTP 200` if there is at least one worker ready to take the request (i.e., not
+currently busy with another request). If there is no worker ready or all workers are busy, the endpoint will return 
+`HTTP 500` status code (you can override this too).
+
 ## Customizing the Not-Ready Status Code
 
 By default, Status Plugin uses a `500` status code. However, you can replace this status code with a custom one.


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a "readiness check" endpoint that provides real-time status of worker availability. It returns an HTTP 200 status code if there is at least one worker ready to take a request, and an HTTP 500 status code if all workers are busy or unavailable. The default not-ready status code can be customized.
- Documentation: Added detailed explanation about the internal request queue mechanism in RR (presumably a web server). This includes how `allocate_timeout` is used to assign workers to requests and the process for rejecting requests when the timeout is exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->