### PR TITLE
Feature/v2023.3

### DIFF
--- a/docs/en/app-server/systemd.md
+++ b/docs/en/app-server/systemd.md
@@ -45,3 +45,16 @@ This will start RoadRunner as a daemon on the server.
 
 For more information about systemd unit files, the user can refer to the
 following [link](https://wiki.archlinux.org/index.php/systemd#Writing_unit_files).
+
+## SDNotify support
+
+RR supports SDNotify protocol. You can use it to notify systemd about the readiness of your application. You don't need
+to configure anything, RR will automatically detect systemd and send the notification. The only one option which might be
+configured is watchdog timeout. By default, it's turned off. You can enable it by setting the following option in your 
+`.rr.yaml` config:
+
+```yaml
+endure:
+  log_level: error
+  watchdog_sec: 60 # watchdog timeout in seconds
+```

--- a/docs/en/kv/boltdb.md
+++ b/docs/en/kv/boltdb.md
@@ -36,7 +36,7 @@ kv:
 
 ## Options
 
-Below is a more detailed description of each of the boltdb-specific options:
+Below is a more detailed description of the various boltdb options.:
 
 ### File
 

--- a/docs/en/kv/memory.md
+++ b/docs/en/kv/memory.md
@@ -19,20 +19,7 @@ kv:
     # Required section.
     # Should be "memory" for the memory driver.
     driver: memory
-
-    config:
-      # Optional section.
-      # Default: 60
-      interval: 60
+    config: {}
 ```
 
-## Options
-
-Below is a more detailed description of each of the memory-specific options:
-
-### Interval
-
-`interval`: The interval (in seconds) between checks for the lifetime of the value in the cache. For large values of
-the interval, the cache item will be checked less often for expiration of its lifetime. It is recommended to use large
-values only in cases when the cache is used without expiration values, or in cases when this value is not critical to
-the architecture of your application. Note that the lower this value, the higher the load on the system.
+There are no additional configuration options for this driver. The `in-memory` driver will automatically create callbacks for items with TTL.

--- a/docs/en/kv/overview.md
+++ b/docs/en/kv/overview.md
@@ -232,7 +232,7 @@ php -r "echo sodium_crypto_box_keypair();" > keypair.key
 ```
 
 > **Warning**
-> Do not store security keys in a control versioning systems (like GIT)!
+> Do not store security keys in a control versioning system (like GIT)!
 
 After generating the keypair, you can use it to encrypt and decrypt the data.
 

--- a/docs/en/lab/otel.md
+++ b/docs/en/lab/otel.md
@@ -4,6 +4,7 @@ RoadRunner offers OTEL (OpenTelemetry) plugin, which provides a unified standard
 information. This plugin allows you to send tracing data from RoadRunner to tracing collectors
 like [New Relic](https://newrelic.com/), [Zipkin](https://zipkin.io), [Jaeger](https://www.jaegertracing.io/),
 [Datadog](https://www.datadoghq.com/), and more.
+Starting with `v2023.3`, the `Jaeger` exporter is deprecated. Please use `OTLP` instead: [docs](https://www.jaegertracing.io/docs/1.49/architecture/).
 
 
 ![OpenTelemetry](https://user-images.githubusercontent.com/773481/213914208-cd944ca8-f218-4baf-8a54-5a4e42a1ed40.jpg)
@@ -49,17 +50,17 @@ http:
 
 **The `otel` section of the configuration file contains the following options:**
 
-| Option              | Description                                                                                                                                                                                                                                     |
-|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **insecure**        | a boolean that determines whether to use insecure endpoints (HTTP/HTTPS) or insecure gRPC. The default value is `false`.                                                                                                                        |                                                                                                                                                                                                        |
-| **compress**        | a boolean that determines whether to use gzip to compress the spans. The default value is `false`.                                                                                                                                              |
-| **exporter**        | a string that provides functionality to emit telemetry to consumers. Possible values are `otlp` (used for New Relic, Datadog), `zipkin`, `stdout`, `jaeger`, or `jaeger_agent` to use a Jaeger agent UDP endpoint. The default value is `otlp`. |
-| **custom_url**      | a string that is used for the http client to override the default URL. The default value is `empty`.                                                                                                                                            |
-| **client**          | a string that determines the client to send the spans. Possible values are http and grpc. The default value is `http`.                                                                                                                          |
-| **endpoint**        | a string that specifies the consumer's endpoint. The default value is `127.0.0.1:4318`.                                                                                                                                                         |
-| **service_name**    | a string that specifies the user's service name. The default value is `RoadRunner`.                                                                                                                                                             |
-| **service_version** | a string that specifies the user's service version. The default value is `1.0.0`.                                                                                                                                                               |
-| **headers**         | a key-value map that contains user-defined headers. The `api-key` for New Relic should be here.                                                                                                                                                 |
+| Option              | Description                                                                                                                                                                                         |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **insecure**        | a boolean that determines whether to use insecure endpoints (HTTP/HTTPS) or insecure gRPC. The default value is `false`.                                                                            |                                                                                                                                                                                                        |
+| **compress**        | a boolean that determines whether to use gzip to compress the spans. The default value is `false`.                                                                                                  |
+| **exporter**        | a string that provides functionality to emit telemetry to consumers. Possible values are `otlp` (used for New Relic, Datadog, Jaeger), `zipkin`, `stdout` or `stderr`. The default value is `otlp`. |
+| **custom_url**      | a string that is used for the http client to override the default URL. The default value is `empty`.                                                                                                |
+| **client**          | a string that determines the client to send the spans. Possible values are http and grpc. The default value is `http`.                                                                              |
+| **endpoint**        | a string that specifies the consumer's endpoint. The default value is `127.0.0.1:4318`.                                                                                                             |
+| **service_name**    | a string that specifies the user's service name. The default value is `RoadRunner`.                                                                                                                 |
+| **service_version** | a string that specifies the user's service version. The default value is `1.0.0`.                                                                                                                   |
+| **headers**         | a key-value map that contains user-defined headers. The `api-key` for New Relic should be here.                                                                                                     |
 
 ## Collector
 
@@ -176,6 +177,27 @@ server:
     - OTEL_PHP_TRACES_PROCESSOR: simple
   relay: pipes
 ```
+
+## Supported plugins:
+
+Here is the list of currently supported plugin
+
+| Plugin/Driver | Description                                                                                  |
+|---------------|----------------------------------------------------------------------------------------------|
+| **Redis**     | Redis driver, e.g.: [link](https://redis.uptrace.dev/guide/go-redis-monitoring.html#uptrace) |
+| **Memcached** | Memcached driver. Native OTEL integration.                                                   |
+| **In-Memory** | In-Memory KV/Jobs driver.                                                                    |
+| **BoltDB**    | Jobs and KV drivers.                                                                         |
+| **KV**        | KV PRC layer.                                                                                |
+| **HTTP**      | HTTP plugin with all HTTP middleware (gzip, http_tracing, headers, etc).                     |
+| **JOBS**      | JOBS plugin RPC layer.                                                                       |
+| **AMQP**      | AMQP driver.                                                                                 |
+| **SQS**       | SQS driver.                                                                                  |
+| **Kafka**     | Kafka driver.                                                                                |
+| **NATS**      | NATS driver.                                                                                 |
+| **Beanstalk** | Beanstalk driver.                                                                            |
+
+
 
 
 > **Note**

--- a/docs/en/lab/otel.md
+++ b/docs/en/lab/otel.md
@@ -27,11 +27,15 @@ Here is an example configuration file:
 version: "3"
 
 otel:
+  # https://github.com/open-telemetry/opentelemetry-specification/blob/v1.25.0/specification/resource/semantic_conventions/README.md
+  resources:
+    service_name: "rr_test"
+    service_version: "1.0.0"
+    service_namespace: "RR-Shop"
+    service_instance_id: "UUID"
   insecure: true
   compress: false
   exporter: otlp
-  service_name: rr_test
-  service_version: 1.0.0
   endpoint: 127.0.0.1:4317
 ```
 
@@ -61,6 +65,7 @@ http:
 | **service_name**    | a string that specifies the user's service name. The default value is `RoadRunner`.                                                                                                                 |
 | **service_version** | a string that specifies the user's service version. The default value is `1.0.0`.                                                                                                                   |
 | **headers**         | a key-value map that contains user-defined headers. The `api-key` for New Relic should be here.                                                                                                     |
+| **resources**       | a key-value map that contains OTEL resources (https://github.com/open-telemetry/opentelemetry-specification/blob/v1.25.0/specification/resource/semantic_conventions/README.md)                     |
 
 ## Collector
 

--- a/docs/en/plugins/grpc.md
+++ b/docs/en/plugins/grpc.md
@@ -8,7 +8,7 @@ It consists of two main parts:
    service definition file (`.proto`). It generates PHP classes that correspond to the service definition and message
    types. These classes provide an interface for handling incoming gRPC requests and sending responses back to the
    client.
-2. **gRPC  server:** This is a server that starts PHP workers and listens for incoming gRPC requests. It receives 
+2. **gRPC server:** This is a server that starts PHP workers and listens for incoming gRPC requests. It receives 
    requests from gRPC clients, proxies them to the PHP workers, and sends the responses back to the client. The server 
    is responsible for managing the lifecycle of the PHP workers and ensuring that they are available to handle requests.
 
@@ -60,7 +60,7 @@ the GitHub releases page.
 The simplest way to get the latest version of `protoc-gen-php-grpc` plugin is to download one of the pre-built release
 binaries on the GitHub [releases page](https://github.com/roadrunner-server/roadrunner/releases).
 
-Just download the appropriate archive from the releases page and extract it into your desired application directory.
+Just download the appropriate archive from the release page and extract it into your desired application directory.
 
 :::
 
@@ -75,7 +75,7 @@ latest version of `protoc-gen-php-grpc` plugin to your project's root directory.
 composer require spiral/roadrunner-cli
 ```
 
-And run the following command to download the latest version of plugin
+And run the following command to download the latest version of the plugin
 
 ```terminal
 ./vendor/bin/rr download-protoc-binary
@@ -107,7 +107,7 @@ protoc --plugin=protoc-gen-php-grpc \
 After running the command, you can find the generated DTO and `PingerInterface` files in
 the `<app>/generated/GRPC/Pinger` directory.
 
-We recommend also to register the GRPC namespace in the `composer.json` file:
+We recommend also registering the GRPC namespace in the `composer.json` file:
 
 ```json
 {
@@ -121,6 +121,11 @@ We recommend also to register the GRPC namespace in the `composer.json` file:
 ```
 
 By doing this, you can easily use the generated PHP classes in your application.
+
+### Using BUF plugin
+
+You can also use the [BUF](https://buf.build/community/roadrunner-server-php-grpc) plugin
+to generate PHP code from the `.proto` file.
 
 ## PHP Client
 
@@ -420,7 +425,7 @@ grpc:
 
 ## Minimal dependencies
 
-1. `Server` plugin for the workers pool.
+1. `Server` plugin for the worker pool.
 2. `Logger` plugin to show log messages.
 3. `Config` plugin to read and populate plugin's configuration.
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes for Pull Request:

- New Feature: Added support for SDNotify protocol in RoadRunner, enabling the application to notify systemd about its readiness. Watchdog timeout can now be configured in `.rr.yaml`.
- Documentation: Updated boltdb-specific options description for clarity.
- Refactor: Removed `interval` option from `kv` configuration in memory driver and added clarifying comments.
- Documentation: Fixed a typo in kv/overview.md.
- Deprecation Notice: Starting with version `v2023.3`, Jaeger exporter is deprecated in favor of OTLP (OpenTelemetry Protocol). An example configuration file for `otel` section has been provided.
- Documentation: Minor updates in grpc.md including typo fixes, URL updates, and clarified instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->