### PR TITLE
Fix typo in static.md

### DIFF
--- a/docs/en/http/static.md
+++ b/docs/en/http/static.md
@@ -47,7 +47,7 @@ version: "3"
 http:
   # host and port separated by semicolon
   address: 127.0.0.1:44933
-  middleware: [ "static", headers", "gzip" ]
+  middleware: [ "static", "headers", "gzip" ]
   # Settings for "headers" middleware (docs: https://roadrunner.dev/docs/http-http/2023.x/en).
   headers:
     cors:


### PR DESCRIPTION
Add missing double quote on middleware values example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed a typo in the HTTP server configuration file, ensuring correct application of the "headers" middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->