### PR TITLE
Explain `allowed_origin_regex` option for headers plugin

### DIFF
--- a/docs/en/http/headers.md
+++ b/docs/en/http/headers.md
@@ -16,6 +16,8 @@ http:
   headers:
     cors:
       allowed_origin: "*"
+      # If `allowed_origin_regex` option is set, the content of `allowed_origin` is ignored
+      allowed_origin_regex: "^http://foo"
       allowed_headers: "*"
       allowed_methods: "GET,POST,PUT,DELETE"
       allow_credentials: true


### PR DESCRIPTION
https://github.com/roadrunner-server/headers/pull/64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Introduced `allowed_origin_regex` option in CORS headers configuration for more flexible specification of allowed origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->