### PR TITLE
Add note about adding http_metrics middleware for http metrics

### DIFF
--- a/docs/en/lab/metrics.md
+++ b/docs/en/lab/metrics.md
@@ -38,6 +38,16 @@ The general metrics provided by the metrics plugin include:
 
 ### HTTP Metrics
 
+> **Note**
+> To enable specific HTTP metrics, you need to add an HTTP middleware called `http_metrics` to the `http.middleware`
+> section of your configuration file.
+> 
+> **Here is an example:**
+> ```yaml
+> http:
+>   middleware: [ "http_metrics" ]
+> ```
+
 The HTTP metrics provided by the metrics plugin include:
 
 - `rr_http_requests_queue` - Total number of queued requests waiting for a worker.


### PR DESCRIPTION
If the `http.middleware` section in the Roadrunner configuration file does not include the `http_metrics` middleware, not all metrics will be available on the HTTP metrics page. Many charts in the HTTP Grafana dashboard will be empty.

It would be appropriate to mention this on the metrics page, as it may not be intuitive to everyone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the metrics documentation to include instructions for enabling HTTP metrics through new middleware configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->